### PR TITLE
一个生成总览的用户脚本

### DIFF
--- a/xp/index.html
+++ b/xp/index.html
@@ -34,5 +34,6 @@
     <script src="ink.js"></script>
     <script src="Untitled.js"></script>
     <script src="main.js"></script>
+    <script src="summary.js"></script>
 </body>
 </html>

--- a/xp/summary.js
+++ b/xp/summary.js
@@ -1,0 +1,93 @@
+// ==UserScript==
+// @name         深渊凝视着你 - 生成总览
+// @namespace    dwscdv3
+// @version      0.1.0
+// @author       Dwscdv3
+// @match        *://note.one.rbq.today/xp/*
+// @match        *://starinitial.github.io/xpcheck/xp/*
+// @grant        none
+// ==/UserScript==
+
+(function() {
+    'use strict';
+
+    const colors = {
+        喜欢: '#393',
+        接受: '#993',
+        不接受: '#933',
+        无所谓: '#333',
+    };
+    let keywords = [];
+
+    const observer = new MutationObserver(mutations => {
+        for (const mutation of mutations) {
+            if (mutation.target.textContent.includes('总分')) {
+                observer.disconnect();
+                keywords = [...$('#story').querySelectorAll('b')].filter(el => el.textContent.includes('"'));
+                $('#story').style.height = '';
+                printTable('人类级', 0, 24);
+                printTable('猛兽级', 24, 22);
+                printTable('异形级', 46, 20);
+                break;
+            }
+        }
+    });
+    observer.observe($('#story'), { childList: true });
+
+    function printTable(title, start, length) {
+        const elements = [];
+        for (let i = start; i < start + length; i++) {
+            elements.push(createElement('div', {
+                textContent: keywords[i].textContent.trim().replace(/"/g, ''),
+                styles: {
+                    margin: '5px',
+                    padding: '4px 8px',
+                    background: colors[keywords[i].parentNode.nextSibling.textContent.trim()],
+                    borderRadius: '5px',
+                },
+            }));
+        }
+        $('#story').append(
+            createElement('div', {
+                textContent: title,
+                styles: {
+                    textAlign: 'center',
+                    fontWeight: 'bold',
+                },
+            }),
+            createElement('div', {
+                styles: {
+                    display: 'flex',
+                    width: '600px',
+                    margin: '10px',
+                    flexWrap: 'wrap',
+                },
+                children: elements,
+            }),
+        );
+    }
+
+    function $(selector) {
+        return document.querySelector(selector);
+    }
+    function createElement(type, args) {
+        const element = document.createElement(type);
+        for (const prop in args) {
+            const arg = args[prop];
+            if (prop === 'classList' && arg instanceof Array) {
+                element.classList.add(...arg.filter(cls => cls));
+            } else if (prop === 'children' && arg instanceof Array) {
+                element.append(...arg.filter(child => child != null));
+            } else if (prop === 'styles' && arg instanceof Object) {
+                Object.assign(element.style, arg);
+            } else if (prop.startsWith('attr_')) {
+                element.setAttribute(prop.substring(5), arg);
+            } else if (prop.startsWith('on')) {
+                element.addEventListener(prop.substring(2), arg);
+            } else {
+                element[prop] = arg;
+            }
+        }
+        return element;
+    }
+})();


### PR DESCRIPTION
一个~~同样写得很烂的两小时糊出来的~~用户脚本，在测试结束后汇总显示所有的选择。

在检测到“总分”二字后输出总览。

* 喜欢：绿色
* 接受：黄色
* 不接受：红色
* 无所谓：灰色

# 已知问题

* 此 PR 直接修改了生成目录，在 Inky 中重新生成项目会丢失对 index.html 所作的更改。
* 硬编码了每个等级的题目数量，更新题库可能导致其工作不正常。
* 因为 xpcheck 的存档没有答案只有分数，所以此脚本只适用于从头开始测试。

# 示例

![image](https://user-images.githubusercontent.com/8089501/120069973-3d03ab00-c0bb-11eb-8d33-6f7dd524e5dd.png)